### PR TITLE
Fix issue #19: Persist selected tmux session across Emacs restarts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,6 +12,7 @@ tmuxで実行されているAIコーディングエージェントとEmacsを橋
 - **1回限りの通知**: プロンプト検出ごとに1回だけバッファを表示
 - **簡単なテキスト送信**: 選択した領域を自動実行付きでAIエージェントに送信
 - **コンテキスト認識**: 送信テキストにファイルパスと行番号を自動的に含める
+- **セッション永続化**: 選択したtmuxセッションをEmacs再起動後も保持・復元
 
 ## インストール
 
@@ -84,8 +85,9 @@ Emacs起動時に自動的に監視を開始するには:
 4. **複数のtmuxセッションがある場合**:
    - `M-x emacs-ai-agent-bridge-select-session`を使用してセッションを切り替え
    - または、モードラインの`[tmux:0]`表示をクリックしてポップアップメニューから選択
+   - 選択したセッションは自動的に保存され、次回のEmacs起動時に復元されます
 
-**注意**: Emacsは自動的に最初に見つかったtmuxセッションを監視します。特定のセッションを監視したい場合は、設定で`emacs-ai-agent-bridge-tmux-session`を設定してください。
+**注意**: Emacsは自動的に最初に見つかったtmuxセッションを監視します。特定のセッションを監視したい場合は、設定で`emacs-ai-agent-bridge-tmux-session`を設定してください。セッションを対話的に選択した場合、`~/.emacs-ai-agent-bridge-session`に保存され、次回起動時に自動的に復元されます。
 
 ### AIエージェントへのテキスト送信
 
@@ -185,6 +187,9 @@ M-x emacs-ai-agent-bridge-monitor-status
 
 ;; 監視間隔（秒）（デフォルト: 2）
 (setq emacs-ai-agent-bridge-monitor-interval 2)
+
+;; セッション保存先ファイルパス（デフォルト: "~/.emacs-ai-agent-bridge-session"）
+(setq emacs-ai-agent-bridge-session-file "~/.emacs-ai-agent-bridge-session")
 ```
 
 ## 動作の仕組み

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An Emacs extension that bridges an AI coding agent running in tmux with Emacs.
 - **One-time notification**: Display buffer only once per prompt detection
 - **Easy text sending**: Send selected region to AI agent with automatic execution
 - **Context awareness**: Automatically includes file path and line number with sent text
+- **Session persistence**: Selected tmux session is saved and restored across Emacs restarts
 
 ## Installation
 
@@ -84,8 +85,9 @@ Before using this extension, you need to have an AI agent running inside tmux.
 4. **If you have multiple tmux sessions**:
    - Use `M-x emacs-ai-agent-bridge-select-session` to switch sessions
    - Or click on the `[tmux:0]` indicator in the mode-line to select from a popup menu
+   - Your selection is automatically saved and restored on next Emacs startup
 
-**Note**: Emacs will automatically monitor the first tmux session it finds. If you want to monitor a specific session, set `emacs-ai-agent-bridge-tmux-session` in your configuration.
+**Note**: Emacs will automatically monitor the first tmux session it finds. If you want to monitor a specific session, set `emacs-ai-agent-bridge-tmux-session` in your configuration. When you select a session interactively, it is saved to `~/.emacs-ai-agent-bridge-session` and automatically restored on next startup.
 
 ### Send Text to AI Agent
 
@@ -185,6 +187,9 @@ M-x emacs-ai-agent-bridge-monitor-status
 
 ;; Monitoring interval in seconds (default: 2)
 (setq emacs-ai-agent-bridge-monitor-interval 2)
+
+;; File path to save the last selected session (default: "~/.emacs-ai-agent-bridge-session")
+(setq emacs-ai-agent-bridge-session-file "~/.emacs-ai-agent-bridge-session")
 ```
 
 ## How It Works

--- a/emacs-ai-agent-bridge.el
+++ b/emacs-ai-agent-bridge.el
@@ -64,6 +64,12 @@ Negative values capture from that many lines back in the scrollback buffer."
   :type 'integer
   :group 'emacs-ai-agent-bridge)
 
+(defcustom emacs-ai-agent-bridge-session-file "~/.emacs-ai-agent-bridge-session"
+  "File path to save the last selected tmux session name.
+The session name is persisted so it can be restored after Emacs restart."
+  :type 'string
+  :group 'emacs-ai-agent-bridge)
+
 
 (defvar emacs-ai-agent-bridge--monitor-timer nil
   "Timer object for periodic monitoring.")
@@ -105,6 +111,25 @@ Sorts session names using natural sort order (0, 1, 2, ..., then alphabetically)
         nil
       (split-string output "\n" t))))
 
+(defun emacs-ai-agent-bridge-save-session ()
+  "Save the current tmux session name to file for persistence across restarts."
+  (when emacs-ai-agent-bridge-tmux-session
+    (with-temp-file (expand-file-name emacs-ai-agent-bridge-session-file)
+      (insert emacs-ai-agent-bridge-tmux-session))))
+
+(defun emacs-ai-agent-bridge-load-session ()
+  "Load the saved tmux session name from file if it still exists.
+Returns the session name if successfully restored, nil otherwise."
+  (let ((file (expand-file-name emacs-ai-agent-bridge-session-file)))
+    (when (file-exists-p file)
+      (let ((saved-session (with-temp-buffer
+                             (insert-file-contents file)
+                             (string-trim (buffer-string)))))
+        (when (and (not (string-empty-p saved-session))
+                   (member saved-session (emacs-ai-agent-bridge-get-all-tmux-sessions)))
+          (setq emacs-ai-agent-bridge-tmux-session saved-session)
+          saved-session)))))
+
 (defun emacs-ai-agent-bridge-select-session ()
   "Select a tmux session from available sessions and switch to it."
   (interactive)
@@ -117,6 +142,7 @@ Sorts session names using natural sort order (0, 1, 2, ..., then alphabetically)
                     nil t)))
     (when selected
       (setq emacs-ai-agent-bridge-tmux-session selected)
+      (emacs-ai-agent-bridge-save-session)
       ;; モニタリング中であれば再起動
       (when emacs-ai-agent-bridge--monitor-timer
         (emacs-ai-agent-bridge-stop-monitoring)
@@ -133,6 +159,7 @@ Sorts session names using natural sort order (0, 1, 2, ..., then alphabetically)
       (let ((selected (popup-menu* sessions)))
         (when selected
           (setq emacs-ai-agent-bridge-tmux-session selected)
+          (emacs-ai-agent-bridge-save-session)
           ;; モニタリング中であれば再起動
           (when emacs-ai-agent-bridge--monitor-timer
             (emacs-ai-agent-bridge-stop-monitoring)
@@ -505,10 +532,11 @@ Includes scrollback history based on `emacs-ai-agent-bridge-scrollback-lines'."
     (cancel-timer emacs-ai-agent-bridge--monitor-timer))
   (setq emacs-ai-agent-bridge--last-capture nil)  ; Reset last capture
   (setq emacs-ai-agent-bridge--prompt-detected nil)  ; Reset detection flag
-  ;; Fix session if not already set
+  ;; Fix session if not already set: try loading saved session first
   (unless emacs-ai-agent-bridge-tmux-session
-    (setq emacs-ai-agent-bridge-tmux-session
-          (emacs-ai-agent-bridge-get-first-tmux-session)))
+    (or (emacs-ai-agent-bridge-load-session)
+        (setq emacs-ai-agent-bridge-tmux-session
+              (emacs-ai-agent-bridge-get-first-tmux-session))))
   (setq emacs-ai-agent-bridge--monitor-timer
         (run-with-timer 0 emacs-ai-agent-bridge-monitor-interval
                         #'emacs-ai-agent-bridge-monitor-tmux))


### PR DESCRIPTION
Save the selected tmux session to ~/.emacs-ai-agent-bridge-session and restore it on next startup. This prevents losing the session selection when Emacs is restarted.